### PR TITLE
Remove mention of the dashboard route, we use home

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -33,7 +33,7 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
-        return redirect()->intended(route('dashboard', absolute: false));
+        return redirect()->intended(route('home', absolute: false));
     }
 
     /**

--- a/app/Http/Controllers/Auth/ConfirmablePasswordController.php
+++ b/app/Http/Controllers/Auth/ConfirmablePasswordController.php
@@ -36,6 +36,6 @@ class ConfirmablePasswordController extends Controller
 
         $request->session()->put('auth.password_confirmed_at', time());
 
-        return redirect()->intended(route('dashboard', absolute: false));
+        return redirect()->intended(route('home', absolute: false));
     }
 }

--- a/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationNotificationController.php
@@ -14,7 +14,7 @@ class EmailVerificationNotificationController extends Controller
     public function store(Request $request): RedirectResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('dashboard', absolute: false));
+            return redirect()->intended(route('home', absolute: false));
         }
 
         $request->user()->sendEmailVerificationNotification();

--- a/app/Http/Controllers/Auth/EmailVerificationPromptController.php
+++ b/app/Http/Controllers/Auth/EmailVerificationPromptController.php
@@ -16,7 +16,7 @@ class EmailVerificationPromptController extends Controller
     public function __invoke(Request $request): RedirectResponse|Response
     {
         return $request->user()->hasVerifiedEmail()
-                    ? redirect()->intended(route('dashboard', absolute: false))
+                    ? redirect()->intended(route('home', absolute: false))
                     : Inertia::render('Auth/VerifyEmail', ['status' => session('status')]);
     }
 }

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -46,6 +46,6 @@ class RegisteredUserController extends Controller
 
         Auth::login($user);
 
-        return redirect(route('dashboard', absolute: false));
+        return redirect(route('home', absolute: false));
     }
 }

--- a/app/Http/Controllers/Auth/VerifyEmailController.php
+++ b/app/Http/Controllers/Auth/VerifyEmailController.php
@@ -15,13 +15,13 @@ class VerifyEmailController extends Controller
     public function __invoke(EmailVerificationRequest $request): RedirectResponse
     {
         if ($request->user()->hasVerifiedEmail()) {
-            return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+            return redirect()->intended(route('home', absolute: false).'?verified=1');
         }
 
         if ($request->user()->markEmailAsVerified()) {
             event(new Verified($request->user()));
         }
 
-        return redirect()->intended(route('dashboard', absolute: false).'?verified=1');
+        return redirect()->intended(route('home', absolute: false).'?verified=1');
     }
 }

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -27,7 +27,7 @@ class AuthenticationTest extends TestCase
         ]);
 
         $this->assertAuthenticated();
-        $response->assertRedirect(route('dashboard', absolute: false));
+        $response->assertRedirect(route('home', absolute: false));
     }
 
     public function test_users_can_not_authenticate_with_invalid_password(): void

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -38,7 +38,7 @@ class EmailVerificationTest extends TestCase
 
         Event::assertDispatched(Verified::class);
         $this->assertTrue($user->fresh()->hasVerifiedEmail());
-        $response->assertRedirect(route('dashboard', absolute: false).'?verified=1');
+        $response->assertRedirect(route('home', absolute: false).'?verified=1');
     }
 
     public function test_email_is_not_verified_with_invalid_hash(): void

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -26,6 +26,6 @@ class RegistrationTest extends TestCase
         ]);
 
         $this->assertAuthenticated();
-        $response->assertRedirect(route('dashboard', absolute: false));
+        $response->assertRedirect(route('home', absolute: false));
     }
 }


### PR DESCRIPTION
This pull request updates several redirection routes in the authentication and verification controllers and related tests to redirect users to the `home` route instead of the `dashboard` route.

### Changes to redirection routes:

* [`app/Http/Controllers/Auth/AuthenticatedSessionController.php`](diffhunk://#diff-0da8f67ed506c71db3d38ddb6c6130cbd358c10a0a71635231fb0a7b7b77ef15L36-R36): Updated redirection in `store` method to use `home` route.
* [`app/Http/Controllers/Auth/ConfirmablePasswordController.php`](diffhunk://#diff-b01c666de4048fc692efa9409eb9c13486dabe42b6627fd285eb5360bf7b7fc0L39-R39): Updated redirection in `store` method to use `home` route.
* [`app/Http/Controllers/Auth/EmailVerificationNotificationController.php`](diffhunk://#diff-62d8fb84dbb5698994966229bdcb5f81f9e1cb918fe757c5ec901ba8c8626504L17-R17): Updated redirection in `store` method to use `home` route.
* [`app/Http/Controllers/Auth/EmailVerificationPromptController.php`](diffhunk://#diff-6a2831e261b6b3139b752e3aeb4d40d9855bc05278ae1ebbd0f4ee9157c33c2fL19-R19): Updated redirection in `__invoke` method to use `home` route.
* [`app/Http/Controllers/Auth/RegisteredUserController.php`](diffhunk://#diff-40125ead6a3f9e88fc596eaa1d70fd7f32411914f62d7754e44006c15c28f198L49-R49): Updated redirection in `store` method to use `home` route.
* [`app/Http/Controllers/Auth/VerifyEmailController.php`](diffhunk://#diff-7ab59aa0ba01de5612b507874998d4d36490e9aca74bd5949ac534d225173ce1L18-R25): Updated redirection in `__invoke` method to use `home` route.

### Changes to related tests:

* [`tests/Feature/Auth/AuthenticationTest.php`](diffhunk://#diff-8a1504d1eb485ec7a9b985c9d22c4d508a3fc0acc962637a333fefcd89fd3c86L30-R30): Updated redirection assertion in `test_users_can_authenticate_using_the_login_screen` method to use `home` route.
* [`tests/Feature/Auth/EmailVerificationTest.php`](diffhunk://#diff-c8aff96c43bfb8a87629e7c080b1338198427568375472a903a6e53cff22018dL41-R41): Updated redirection assertion in `test_email_can_be_verified` method to use `home` route.
* [`tests/Feature/Auth/RegistrationTest.php`](diffhunk://#diff-6070c92132fc193ef4af8fea61acec19455f2aa945cab4ce7ffa20257f1ba168L29-R29): Updated redirection assertion in `test_new_users_can_register` method to use `home` route.